### PR TITLE
Renaming to reflect move to Management framework naming in Zeek

### DIFF
--- a/Docker/setups/default/zeekscripts/agent.zeek
+++ b/Docker/setups/default/zeekscripts/agent.zeek
@@ -1,5 +1,5 @@
-@load policy/frameworks/cluster/agent
+@load policy/frameworks/management/agent
 
-redef ClusterAgent::directory = "/var/log/zeek/mgmt";
-redef ClusterAgent::cluster_directory = "/var/log/zeek/cluster";
-redef ClusterAgent::controller = [$address="controller", $bound_port=2150/tcp];
+redef Management::Agent::directory = "/var/log/zeek/mgmt";
+redef Management::Agent::cluster_directory = "/var/log/zeek/cluster";
+redef Management::Agent::controller = [$address="controller", $bound_port=2150/tcp];

--- a/Docker/setups/default/zeekscripts/controller.zeek
+++ b/Docker/setups/default/zeekscripts/controller.zeek
@@ -1,8 +1,3 @@
-@load policy/frameworks/cluster/controller
+@load policy/frameworks/management/controller
 
-redef ClusterController::directory = "/var/log/zeek/mgmt";
-
-#redef ClusterController::instances = {
-#	["inst1"] = ClusterController::Types::Instance($name="", $host="inst1", $listen_port=2151/tcp),
-#	["inst2"] = ClusterController::Types::Instance($name="", $host="inst2", $listen_port=2151/tcp),
-#};
+redef Management::Controller::directory = "/var/log/zeek/mgmt";

--- a/Docker/setups/singlehost/zeekscripts/agent-local.zeek
+++ b/Docker/setups/singlehost/zeekscripts/agent-local.zeek
@@ -1,0 +1,1 @@
+@load policy/frameworks/management

--- a/Docker/setups/singlehost/zeekscripts/agent.zeek
+++ b/Docker/setups/singlehost/zeekscripts/agent.zeek
@@ -1,5 +1,5 @@
-@load policy/frameworks/cluster/agent
+@load policy/frameworks/management/agent
 @load ./agent-local.zeek
 
-redef ClusterAgent::directory = "/var/log/zeek/mgmt";
-redef ClusterAgent::cluster_directory = "/var/log/zeek/cluster";
+redef Management::Agent::directory = "/var/log/zeek/mgmt";
+redef Management::Agent::cluster_directory = "/var/log/zeek/cluster";

--- a/Docker/setups/singlehost/zeekscripts/controller-local.zeek
+++ b/Docker/setups/singlehost/zeekscripts/controller-local.zeek
@@ -1,0 +1,1 @@
+@load policy/frameworks/management

--- a/Docker/setups/singlehost/zeekscripts/controller.zeek
+++ b/Docker/setups/singlehost/zeekscripts/controller.zeek
@@ -1,4 +1,4 @@
-@load policy/frameworks/cluster/controller
+@load policy/frameworks/management/controller
 @load ./controller-local.zeek
 
-redef ClusterController::directory = "/var/log/zeek/mgmt";
+redef Management::Controller::directory = "/var/log/zeek/mgmt";

--- a/tests/layout-controller-to-instances
+++ b/tests/layout-controller-to-instances
@@ -15,11 +15,11 @@ docker_compose_up
 # to segregate logs.
 docker_exec controller mkdir /tmp/agent1 /tmp/agent2
 docker_exec -d -w /tmp/agent1 -- controller zeek -j site/testing/agent.zeek \
-    ClusterAgent::name=instance-1 \
+    Management::Agent::name=instance-1 \
     Broker::default_port=10000/tcp
 docker_exec -d -w /tmp/agent2 -- controller zeek -j site/testing/agent.zeek \
-    ClusterAgent::name=instance-2 \
-    ClusterAgent::default_port=2152/tcp \
+    Management::Agent::name=instance-2 \
+    Management::Agent::default_port=2152/tcp \
     Broker::default_port=10001/tcp
 
 zeek_client set-config - <<EOF

--- a/tests/layout-instances-to-controller
+++ b/tests/layout-instances-to-controller
@@ -11,7 +11,7 @@ docker_populate singlehost
 
 # Configure the agents to connect to the controller
 cat >>zeekscripts/agent-local.zeek <<EOF
-redef ClusterAgent::controller = [\$address="127.0.0.1", \$bound_port=2150/tcp];
+redef Management::Agent::controller = [\$address="127.0.0.1", \$bound_port=2150/tcp];
 EOF
 
 docker_compose_up
@@ -21,9 +21,9 @@ docker_compose_up
 # to segregate logs.
 docker_exec controller mkdir /tmp/agent1 /tmp/agent2
 docker_exec -d -w /tmp/agent1 -- controller zeek -j site/testing/agent.zeek \
-    ClusterAgent::name=instance-1 Broker::default_port=10000/tcp
+    Management::Agent::name=instance-1 Broker::default_port=10000/tcp
 docker_exec -d -w /tmp/agent2 -- controller zeek -j site/testing/agent.zeek \
-    ClusterAgent::name=instance-2 Broker::default_port=10001/tcp
+    Management::Agent::name=instance-2 Broker::default_port=10001/tcp
 
 zeek_client set-config - <<EOF
 [instances]

--- a/tests/request-timeout-controller-state
+++ b/tests/request-timeout-controller-state
@@ -15,6 +15,10 @@ docker_populate singlehost
 
 cat >>zeekscripts/controller-local.zeek <<EOF
 redef Management::Request::timeout_interval = 1sec;
+
+# We need to redefine this down, otherwise the low request timeout
+# will be masked by the higher table-checking default value of 10sec:
+redef table_expire_interval = 1sec;
 EOF
 
 cat >>etc/zeek-client.cfg <<EOF

--- a/tests/request-timeout-controller-state
+++ b/tests/request-timeout-controller-state
@@ -14,7 +14,7 @@ docker_populate singlehost
 # investigating.
 
 cat >>zeekscripts/controller-local.zeek <<EOF
-redef ClusterController::request_timeout = 1sec;
+redef Management::Request::timeout_interval = 1sec;
 EOF
 
 cat >>etc/zeek-client.cfg <<EOF

--- a/tests/set-configuration
+++ b/tests/set-configuration
@@ -13,7 +13,7 @@ docker_compose_up
 # The Zeek host now runs a controller. Run an agent alongside it.
 docker_exec controller mkdir /tmp/agent
 docker_exec -d -w /tmp/agent -- controller zeek -j site/testing/agent.zeek \
-    ClusterAgent::name=instance-1 \
+    Management::Agent::name=instance-1 \
     Broker::default_port=10000/tcp
 
 zeek_client set-config - <<EOF


### PR DESCRIPTION
I haven't so far done PRs for updates to the testsuite but it might help to get eyes on it, so this is the corresponding update to zeek/zeek#1960, with one additional fix to a request state timeout test: it now actually runs as fast as it should.