### PR TITLE
Switch Docker images from Fedora to Debian

### DIFF
--- a/Docker/docker.final/Dockerfile
+++ b/Docker/docker.final/Dockerfile
@@ -1,17 +1,24 @@
-FROM fedora:35
+FROM debian:bullseye-slim
 LABEL maintainer="Christian Kreibich <christian@corelight.com>"
-
-# Packages for future dev usage (building plugins, running Zeek itself, etc)
-ARG devrpms="cmake gcc gcc-c++ libpcap make"
-# Packages for zkg
-ARG zkgrpms="python3-GitPython python3-semantic_version"
-# Packages for additional tooling
-ARG toolrpms="bind-utils findutils procps-ng net-tools telnet psmisc"
 
 ENV PATH "/usr/local/zeek/bin:${PATH}"
 ENV PYTHONPATH "/usr/local/zeek/lib/zeek/python:${PYTHONPATH}"
 
-RUN dnf install -y $devrpms $zkgrpms $toolrpms && dnf clean all
+# This installs the same set of packages we also provide in the official Docker image.
+RUN apt-get -q update \
+ && apt-get install -q -y --no-install-recommends \
+     ca-certificates \
+     git \
+     libmaxminddb0 \
+     libpython3.9 \
+     libpcap0.8 \
+     libssl1.1 \
+     libz1 \
+     python3-minimal \
+     python3-git \
+     python3-semantic-version \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/local/zeek/var/lib
 

--- a/Docker/docker.prebuild/Dockerfile
+++ b/Docker/docker.prebuild/Dockerfile
@@ -1,9 +1,30 @@
-FROM fedora:35
+FROM debian:bullseye-slim
 LABEL maintainer="Christian Kreibich <christian@corelight.com>"
 
-# Requirements for the Zeek build
-RUN dnf install -y bison ccache cmake gcc gcc-c++ make python3 findutils \
-    flex git libpcap-devel openssl-devel python3-devel swig zlib-devel
+# Configure system for build.
+RUN apt-get -q update \
+ && apt-get install -q -y --no-install-recommends \
+     bind9 \
+     bison \
+     ccache \
+     cmake \
+     flex \
+     g++ \
+     gcc \
+     libfl2 \
+     libfl-dev \
+     libmaxminddb-dev \
+     libpcap-dev \
+     libssl-dev \
+     libz-dev \
+     make \
+     python3-minimal \
+     python3.9-dev \
+     swig \
+     ninja-build \
+     python3-pip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Zeek-related locations in our image
 ENV ZEEK_DIR=/zeek


### PR DESCRIPTION
This brings them in line with the official Zeek image, which is the one we use
in CI. So far the different distros made no difference, but we're starting to
need additional tooling for testing purposes, so it's helpful to be able to
install it in the same way.