### PR TITLE
Preserve `zeek-client` outputs during pipelines

### DIFF
--- a/tests/deploy-a2c.sh
+++ b/tests/deploy-a2c.sh
@@ -44,7 +44,8 @@ wait_for_all_nodes_running || fail "nodes did not end up running"
 
 # Remove the id field (containing the deployed configuration's UUID),
 # so we can diff it.
-zeek_client get-config --as-json --deployed | jq 'del(.id)' >output.json
+zeek_client get-config --as-json --deployed \
+    | tee output.zc.json | jq 'del(.id)' >output.json
 
 # The INI format does not include the ID field.
 zeek_client get-config --deployed >output.ini

--- a/tests/deploy-agent-only.sh
+++ b/tests/deploy-agent-only.sh
@@ -14,7 +14,7 @@ docker_compose_up
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
 
-zeek_client deploy-config - <<EOF | jq '.results.id = "xxx"' >output
+zeek_client deploy-config - <<EOF | tee output.zc | jq '.results.id = "xxx"' >output
 [instances]
 instance-1
 EOF

--- a/tests/deploy-c2a.sh
+++ b/tests/deploy-c2a.sh
@@ -47,7 +47,7 @@ wait_for_all_nodes_running || fail "nodes did not end up running"
 
 # Remove the id field (containing the deployed configuration's UUID),
 # so we can diff it.
-zeek_client get-config --as-json --deployed | jq 'del(.id)' >output.json
+zeek_client get-config --as-json --deployed | tee output.zc.json | jq 'del(.id)' >output.json
 
 # The INI format does not include the ID field.
 zeek_client get-config --deployed >output.ini

--- a/tests/deploy-error.sh
+++ b/tests/deploy-error.sh
@@ -24,6 +24,7 @@ set +e
 # replace the stderr string (which has a lot of detail, making it bad for
 # baselining) with something simpler:
 cat $FILES/config.ini | zeek_client deploy-config - \
+    | tee output.zc \
     | jq '.results.id = "xxx"' \
     | jq '.results.nodes.logger.stderr |= sub(".+unknown identifier EEEK.+"; "unknown identifier EEEK"; "m")' >output
 

--- a/tests/deploy-minimal.sh
+++ b/tests/deploy-minimal.sh
@@ -38,4 +38,5 @@ EOF
 
 wait_for_all_nodes_running || fail "nodes did not end up running"
 
-zeek_client get-config --as-json --deployed | jq 'del(.id)' >output.json
+zeek_client get-config --as-json --deployed \
+    | tee output.zc.json | jq 'del(.id)' >output.json

--- a/tests/get-config.sh
+++ b/tests/get-config.sh
@@ -57,7 +57,9 @@ zeek_client get-config --deployed >output-predeploy-deployed.error 2>&1 \
 
 # Remove the id field (containing the deployed configuration's UUID),
 # so we can diff it.
-zeek_client get-config --as-json | jq 'del(.id)' >output-predeploy-staged.json
+zeek_client get-config --as-json \
+    | tee output.zc.predeploy-staged.json \
+    | jq 'del(.id)' >output-predeploy-staged.json
 
 # The INI format does not include the ID field.
 zeek_client get-config >output.ini
@@ -65,11 +67,17 @@ zeek_client get-config >output.ini
 zeek_client deploy
 wait_for_all_nodes_running || fail "nodes did not end up running"
 
-zeek_client get-config --as-json --deployed | jq 'del(.id)' >output-postdeploy-deployed.json
-zeek_client get-config --as-json | jq 'del(.id)' >output-postdeploy-staged.json
+zeek_client get-config --as-json --deployed \
+    | tee output.zc.postdeploy-deployed.json \
+    | jq 'del(.id)' >output-postdeploy-deployed.json
+zeek_client get-config --as-json \
+    | tee output.zc.postdeploy-staged.son \
+    | jq 'del(.id)' >output-postdeploy-staged.json
 
 # The above produced the output files locally, not in the Docker container.
 cat output.ini | zeek_client deploy-config -
 wait_for_all_nodes_running || fail "nodes did not end up running"
 
-zeek_client get-config --as-json --deployed | jq 'del(.id)' >output-postredeploy-deployed.json
+zeek_client get-config --as-json --deployed \
+    | tee output.zc.postredeploy-deployed.json \
+    | jq 'del(.id)' >output-postredeploy-deployed.json

--- a/tests/get-id-value.sh
+++ b/tests/get-id-value.sh
@@ -68,33 +68,33 @@ wait_for_all_nodes_running || fail "nodes did not end up running"
 # On to why we're here -- variations of "zeek-client get-id-value"
 
 # Retrieve a basic value that exists on all nodes:
-run "zeek_client get-id-value bits_per_uid | jq" 0 simple
+run "zeek_client get-id-value bits_per_uid" 0 simple
 btest-diff output.simple
 
 # Retrieve a variable that does not exist:
-run "zeek_client get-id-value this_is_not_defined | jq" 1 unknown
+run "zeek_client get-id-value this_is_not_defined" 1 unknown
 btest-diff output.unknown
 
 # Retrieve a thing that exists but is not a value:
-run "zeek_client get-id-value connection | jq" 1 noid
+run "zeek_client get-id-value connection" 1 noid
 btest-diff output.noid
 
 # Retrieve a more complex value:
-run "zeek_client get-id-value Log::active_streams | jq" 0 complex
+run "zeek_client get-id-value Log::active_streams" 0 complex
 btest-diff output.complex
 
 # Retrieve from a single, existing node:
-run "zeek_client get-id-value bits_per_uid manager | jq" 0 nodes-single
+run "zeek_client get-id-value bits_per_uid manager" 0 nodes-single
 btest-diff output.nodes-single
 
 # Retrieve from select existing nodes:
-run "zeek_client get-id-value bits_per_uid manager logger-01 | jq" 0 nodes-multiple
+run "zeek_client get-id-value bits_per_uid manager logger-01" 0 nodes-multiple
 btest-diff output.nodes-multiple
 
 # Retrieve from select nodes, including invalid ones
-run "zeek_client get-id-value bits_per_uid worker-02 worker-03 | jq" 1 nodes-mixed
+run "zeek_client get-id-value bits_per_uid worker-02 worker-03" 1 nodes-mixed
 btest-diff output.nodes-mixed
 
 # Retrieve from select nodes that do not exist at all
-run "zeek_client get-id-value bits_per_uid worker-03 worker-04 | jq" 1 nodes-invalid
+run "zeek_client get-id-value bits_per_uid worker-03 worker-04" 1 nodes-invalid
 btest-diff output.nodes-invalid

--- a/tests/get-instances-a2c.sh
+++ b/tests/get-instances-a2c.sh
@@ -30,7 +30,7 @@ docker_exec -d -w /tmp/agent2 -- controller zeek -j site/testing/agent.zeek \
 wait_for_instances 2
 
 # Canonicalize the agents' ephemeral ports for baselining:
-zeek_client get-instances | jq '.[].port = "xxx"' >output.pre-config
+zeek_client get-instances | tee output.zc.pre-config | jq '.[].port = "xxx"' >output.pre-config
 
 # This should have no effect on the reported instances.
 zeek_client deploy-config - <<EOF
@@ -39,4 +39,4 @@ instance-1
 instance-2
 EOF
 
-zeek_client get-instances | jq '.[].port = "xxx"' >output.post-config
+zeek_client get-instances | tee output.zc.post-config | jq '.[].port = "xxx"' >output.post-config

--- a/tests/get-nodes.sh
+++ b/tests/get-nodes.sh
@@ -22,7 +22,7 @@ set +e
 
 # The controller should see the instance and its Zeek nodes: an agent and the
 # controller. (Strip the PIDs, since they change from run to run.)
-zeek_client get-nodes | jq 'del(.results[][].pid)' >output.bare \
+zeek_client get-nodes | tee output.zc.bare | jq 'del(.results[][].pid)' >output.bare \
     || fail "get-nodes failed with connected instance"
 
 # Deploy a Zeek cluster and give its nodes time to come up:
@@ -30,4 +30,4 @@ cat $FILES/config.ini | zeek_client deploy-config -
 wait_for_all_nodes_running || fail "nodes did not end up running"
 
 # All nodes should now be there.
-zeek_client get-nodes | jq 'del(.results[][].pid)' >output.nodes
+zeek_client get-nodes | tee output.zc.nodes | jq 'del(.results[][].pid)' >output.nodes

--- a/tests/persistence-state-restart-all.sh
+++ b/tests/persistence-state-restart-all.sh
@@ -79,4 +79,4 @@ zeek_client get-config >output.staged
 zeek_client get-config --deployed >output.deployed
 
 # And, we should have a cluster:
-zeek_client get-nodes | jq 'del(.results[][].pid)' >output.nodes
+zeek_client get-nodes | tee output.zc.nodes | jq 'del(.results[][].pid)' >output.nodes

--- a/tests/stage-config-auto-assign-multi-instance.sh
+++ b/tests/stage-config-auto-assign-multi-instance.sh
@@ -61,4 +61,6 @@ EOF
 wait_for_all_nodes_running || fail "nodes did not end up running"
 
 # Remove PIDs from the nodes, and show only Zeek cluster nodes:
-zeek_client get-nodes | jq 'del(.results[][].pid).results[] | with_entries(select(.value.cluster_role != null))' >output
+zeek_client get-nodes \
+    | tee output.zc \
+    | jq 'del(.results[][].pid).results[] | with_entries(select(.value.cluster_role != null))' >output

--- a/tests/stage-config-auto-assign-new-range.sh
+++ b/tests/stage-config-auto-assign-new-range.sh
@@ -43,5 +43,7 @@ role = worker
 interface = eth0
 EOF
 
-zeek_client get-config --as-json | jq '.id = "xxx"' >output.staged
-zeek_client get-config --as-json --deployed | jq '.id = "xxx"' >output.deployed
+zeek_client get-config --as-json \
+    | tee output.zc.staged | jq '.id = "xxx"' >output.staged
+zeek_client get-config --as-json --deployed \
+    | tee output.zc.deployed | jq '.id = "xxx"' >output.deployed

--- a/tests/stage-config-auto-assign.sh
+++ b/tests/stage-config-auto-assign.sh
@@ -40,5 +40,7 @@ role = worker
 interface = eth0
 EOF
 
-zeek_client get-config --as-json | jq '.id = "xxx"' >output.staged
-zeek_client get-config --as-json --deployed | jq '.id = "xxx"' >output.deployed
+zeek_client get-config --as-json \
+    | tee output.zc.staged | jq '.id = "xxx"' >output.staged
+zeek_client get-config --as-json --deployed \
+    | tee output.zc.deployed | jq '.id = "xxx"' >output.deployed

--- a/tests/stage-config-empty.sh
+++ b/tests/stage-config-empty.sh
@@ -14,4 +14,4 @@ docker_compose_up
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
 
-cat /dev/null | zeek_client deploy-config - | jq '.results.id = "xxx"' >output
+cat /dev/null | zeek_client deploy-config - | tee output.zc | jq '.results.id = "xxx"' >output


### PR DESCRIPTION
This simply runs several `zeek-client` outputs through `tee` to preserve the output as-is, prior to any post-processing by jq or similars. I noticed that this can be quite helpful when troubleshooting failed tests.