### PR TITLE
Various fixes (was: btest: Set COMPOSE_COMPATIBILITY=true)

### DIFF
--- a/Scripts/docker-compose-teardown
+++ b/Scripts/docker-compose-teardown
@@ -11,6 +11,9 @@ if docker ps -a | grep -q $controller; then
     docker cp $controller:/usr/local/zeek/logs controller/logs
 fi
 
+# Grab the Docker logs
+docker-compose -p ${testname}_ -f docker-compose.yml logs >docker-compose.logs
+
 [ -n "$TEST_SKIP_DOCKER_TEARDOWN" ] && exit 0
 [ "$TEST_FAILED" -eq 1 ] && [ -n "$TEST_SKIP_DOCKER_TEARDOWN_ON_FAILURE" ] && exit 0
 
@@ -23,9 +26,6 @@ if [ ! -f docker-compose.yml ]; then
     echo "WARNING: btest teardown found no docker-compose.yml"
     exit 0
 fi
-
-# Grab the Docker logs
-docker-compose -p ${testname}_ -f docker-compose.yml logs >docker-compose.logs
 
 # Don't wait at all for clean container shutdown
 docker-compose -p ${testname}_ -f docker-compose.yml down -t 0

--- a/btest.cfg
+++ b/btest.cfg
@@ -16,6 +16,12 @@ FILES=%(testbase)s/Files
 SCRIPTS=%(testbase)s/Scripts
 DOCKER=%(testbase)s/Docker
 UBSAN_OPTIONS=print_stacktrace=1
+# Enable use of _ separator for docker-compose v2. By default v2 is using '-' as
+# a separator to be more hostname friendly. As we set the compose project
+# to "${testname}_", seems okay to continue using '_' as a separator, too.
+# https://stackoverflow.com/a/69519102
+# https://docs.docker.com/compose/cli-command-compatibility/
+COMPOSE_COMPATIBILITY=true
 
 [environment-debug]
 # After test completion, keep all containers running regardless of test outcome.

--- a/tests/log-archival-different-cmd.sh
+++ b/tests/log-archival-different-cmd.sh
@@ -16,6 +16,8 @@ EOF
 
 # Expand cluster so it periodically logs a message to a new test.log.
 cat >>zeekscripts/local.zeek <<EOF
+@load base/frameworks/cluster
+
 @if ( Cluster::local_node_type() == Cluster::MANAGER || Cluster::local_node_type() == Cluster::LOGGER )
 
 module Test;

--- a/tests/log-archival.sh
+++ b/tests/log-archival.sh
@@ -13,6 +13,8 @@ docker_populate singlehost
 
 # Expand cluster so it periodically logs a message to a new test.log.
 cat >>zeekscripts/local.zeek <<EOF
+@load base/frameworks/cluster
+
 @if ( Cluster::local_node_type() == Cluster::MANAGER || Cluster::local_node_type() == Cluster::LOGGER )
 
 module Test;


### PR DESCRIPTION
Using a v2 docker-compose version uses `-` as separator between project name
and container, breaking some of the assumptions made in the scripts.

Setting COMPOSE_COMPATIBILITY allows to revert to using `_` as a
separator.

    $ docker-compose --version
    Docker Compose version v2.10.2


@ckreibich - is this something you could pick up or see if there's a better way to fix?