### PR TITLE
Fix node state race condition in tests using get-nodes command output

### DIFF
--- a/Baseline/tests.get-nodes/output.bare
+++ b/Baseline/tests.get-nodes/output.bare
@@ -7,12 +7,12 @@
         "cluster_role": null,
         "mgmt_role": "CONTROLLER",
         "port": 2151,
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "instance-1": {
         "cluster_role": null,
         "mgmt_role": "AGENT",
-        "state": "RUNNING"
+        "state": "<canonified>"
       }
     }
   }

--- a/Baseline/tests.get-nodes/output.nodes
+++ b/Baseline/tests.get-nodes/output.nodes
@@ -7,29 +7,29 @@
         "cluster_role": null,
         "mgmt_role": "CONTROLLER",
         "port": 2151,
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "instance-1": {
         "cluster_role": null,
         "mgmt_role": "AGENT",
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "logger": {
         "cluster_role": "LOGGER",
         "mgmt_role": null,
         "port": 5001,
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "manager": {
         "cluster_role": "MANAGER",
         "mgmt_role": null,
         "port": 5000,
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "worker": {
         "cluster_role": "WORKER",
         "mgmt_role": null,
-        "state": "RUNNING"
+        "state": "<canonified>"
       }
     }
   }

--- a/Baseline/tests.persistence-state-restart-all/output.nodes
+++ b/Baseline/tests.persistence-state-restart-all/output.nodes
@@ -7,29 +7,29 @@
         "cluster_role": null,
         "mgmt_role": "CONTROLLER",
         "port": 2151,
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "instance-1": {
         "cluster_role": null,
         "mgmt_role": "AGENT",
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "logger": {
         "cluster_role": "LOGGER",
         "mgmt_role": null,
         "port": 5001,
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "manager": {
         "cluster_role": "MANAGER",
         "mgmt_role": null,
         "port": 5000,
-        "state": "RUNNING"
+        "state": "<canonified>"
       },
       "worker": {
         "cluster_role": "WORKER",
         "mgmt_role": null,
-        "state": "RUNNING"
+        "state": "<canonified>"
       }
     }
   }

--- a/Baseline/tests.stage-config-auto-assign-multi-instance/output
+++ b/Baseline/tests.stage-config-auto-assign-multi-instance/output
@@ -4,25 +4,25 @@
     "cluster_role": "LOGGER",
     "mgmt_role": null,
     "port": 2201,
-    "state": "RUNNING"
+    "state": "<canonified>"
   },
   "manager": {
     "cluster_role": "MANAGER",
     "mgmt_role": null,
     "port": 2200,
-    "state": "RUNNING"
+    "state": "<canonified>"
   },
   "proxy-01": {
     "cluster_role": "PROXY",
     "mgmt_role": null,
     "port": 2203,
-    "state": "RUNNING"
+    "state": "<canonified>"
   },
   "proxy-02": {
     "cluster_role": "PROXY",
     "mgmt_role": null,
     "port": 2204,
-    "state": "RUNNING"
+    "state": "<canonified>"
   }
 }
 {
@@ -30,23 +30,23 @@
     "cluster_role": "LOGGER",
     "mgmt_role": null,
     "port": 2202,
-    "state": "RUNNING"
+    "state": "<canonified>"
   },
   "proxy-03": {
     "cluster_role": "PROXY",
     "mgmt_role": null,
     "port": 2205,
-    "state": "RUNNING"
+    "state": "<canonified>"
   },
   "proxy-04": {
     "cluster_role": "PROXY",
     "mgmt_role": null,
     "port": 2206,
-    "state": "RUNNING"
+    "state": "<canonified>"
   },
   "worker-01": {
     "cluster_role": "WORKER",
     "mgmt_role": null,
-    "state": "RUNNING"
+    "state": "<canonified>"
   }
 }

--- a/Scripts/jq-canonify-nodestate
+++ b/Scripts/jq-canonify-nodestate
@@ -1,0 +1,11 @@
+#! /usr/bin/env bash
+#
+# A zeek-client output filter for get-nodes and related commands that filters
+# stdin to stdout as follows:
+#
+# - removes .pid entries, since they will differ in every run
+#
+# - normalizes cluster node states PENDING and RUNNING to <canonified>, for
+#   tests that do not care which of those two states a node is in.
+
+jq 'del(.results[][].pid) | .results[][] |= if (.state == "PENDING" or .state == "RUNNING") then (.state = "<canonified>") else . end'

--- a/tests/get-nodes.sh
+++ b/tests/get-nodes.sh
@@ -22,7 +22,7 @@ set +e
 
 # The controller should see the instance and its Zeek nodes: an agent and the
 # controller. (Strip the PIDs, since they change from run to run.)
-zeek_client get-nodes | tee output.zc.bare | jq 'del(.results[][].pid)' >output.bare \
+zeek_client get-nodes | tee output.zc.bare | $SCRIPTS/jq-canonify-nodestate >output.bare \
     || fail "get-nodes failed with connected instance"
 
 # Deploy a Zeek cluster and give its nodes time to come up:
@@ -30,4 +30,4 @@ cat $FILES/config.ini | zeek_client deploy-config -
 wait_for_all_nodes_running || fail "nodes did not end up running"
 
 # All nodes should now be there.
-zeek_client get-nodes | tee output.zc.nodes | jq 'del(.results[][].pid)' >output.nodes
+zeek_client get-nodes | tee output.zc.nodes | $SCRIPTS/jq-canonify-nodestate >output.nodes

--- a/tests/persistence-state-restart-all.sh
+++ b/tests/persistence-state-restart-all.sh
@@ -79,4 +79,4 @@ zeek_client get-config >output.staged
 zeek_client get-config --deployed >output.deployed
 
 # And, we should have a cluster:
-zeek_client get-nodes | tee output.zc.nodes | jq 'del(.results[][].pid)' >output.nodes
+zeek_client get-nodes | tee output.zc.nodes | $SCRIPTS/jq-canonify-nodestate >output.nodes

--- a/tests/stage-config-auto-assign-multi-instance.sh
+++ b/tests/stage-config-auto-assign-multi-instance.sh
@@ -63,4 +63,5 @@ wait_for_all_nodes_running || fail "nodes did not end up running"
 # Remove PIDs from the nodes, and show only Zeek cluster nodes:
 zeek_client get-nodes \
     | tee output.zc \
-    | jq 'del(.results[][].pid).results[] | with_entries(select(.value.cluster_role != null))' >output
+    | $SCRIPTS/jq-canonify-nodestate \
+    | jq '.results[] | with_entries(select(.value.cluster_role != null))' >output


### PR DESCRIPTION
The cluster nodes can sometimes be in state PENDING, not yet RUNNING, which triggers baseline deviations. This adds a helper script that canonifies the output at the JSON level. It's much like a btest-diff canonifier, but works best when running directly on `zeek-client get-nodes` output, possibly followed by other commands.