### PR TITLE
git-related fixes for local testsuite operation

### DIFF
--- a/Docker/docker.prebuild/Dockerfile
+++ b/Docker/docker.prebuild/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -q update \
      flex \
      g++ \
      gcc \
+     git \
      libfl2 \
      libfl-dev \
      libmaxminddb-dev \
@@ -41,6 +42,10 @@ ENV VOL_CCACHE_DIR=/mnt/vol/ccache
 ENV CCACHE_DIR=/mnt/vol/ccache
 
 RUN mkdir -p $ZEEK_TOOLS_DIR
+
+# The following volume mount results in a source tree not owned by the user
+# running git on it. Prevent git from complaining about this:
+RUN git config --global --add safe.directory "*"
 
 VOLUME $VOL_SRC_DIR $VOL_BUILD_DIR $VOL_CCACHE_DIR
 

--- a/Docker/make.sh
+++ b/Docker/make.sh
@@ -109,9 +109,9 @@ docker build -t zeektest-prebuild ./docker.prebuild
 
 docker rm -f zeektest-builder 2>/dev/null
 docker run -it --name zeektest-builder \
-       -v "$src_path:/mnt/vol/src:z" \
-       -v "$ccache_path:/mnt/vol/ccache:z" \
-       -v "$build_path:/mnt/vol/build:z" zeektest-prebuild
+       -v "$src_path:/mnt/vol/src:ro,Z" \
+       -v "$ccache_path:/mnt/vol/ccache:Z" \
+       -v "$build_path:/mnt/vol/build:Z" zeektest-prebuild
 docker commit zeektest-builder zeektest-build
 docker rm -f zeektest-builder 2>/dev/null
 


### PR DESCRIPTION
These allow `make docker` to pass again when running locally, which broke due to the new dependency on git and git's insistance on safe directories. This didn't come up in CI because we re-use previously built Docker image in that setting.

Also mount the source tree read-only into the build-stage container, simply since it seems good to do so.