### PR TITLE
Fix Zeek source tree presence check for Docker image build

### DIFF
--- a/Docker/make.sh
+++ b/Docker/make.sh
@@ -44,7 +44,7 @@ if [[ -n "$GITHUB_ACTION" || -n "$CIRRUS_CI" ]]; then
     exit 0
 fi
 
-if have_docker_image && [[ ! -f $src_path/zeek-config.h.in ]]; then
+if have_docker_image && [[ ! -f $src_path/zeek-path-dev.in ]]; then
     msg "No source tree available, using existing ${docker_image}."
     exit 0
 fi


### PR DESCRIPTION
This was still using zeek-config.h.in, which has moved into the cmake_templates subdirectory. It's using zeek-path-dev.in now, which hopefully will stick around.