### PR TITLE
Avoid excessive memory use induced via containerd & libkqueue, avoid warnings

### DIFF
--- a/Docker/docker.final/Dockerfile
+++ b/Docker/docker.final/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:bullseye-slim
 LABEL maintainer="Christian Kreibich <christian@corelight.com>"
 
-ENV PATH "/usr/local/zeek/bin:${PATH}"
-ENV PYTHONPATH "/usr/local/zeek/lib/zeek/python:${PYTHONPATH}"
+ENV PATH="/usr/local/zeek/bin:${PATH}"
+ENV PYTHONPATH="/usr/local/zeek/lib/zeek/python"
 
 # This installs the same set of packages we also provide in the official Docker image.
 RUN apt-get -q update \

--- a/Docker/setups/default/docker-compose.yml
+++ b/Docker/setups/default/docker-compose.yml
@@ -14,12 +14,16 @@ x-zeek-agent: &ZEEK_AGENT
   command: /usr/local/zeek/bin/zeek -j site/testing/agent.zeek
   ports:
     - "9999"
+  ulimits:
+    nofile: 1024
 
 x-zeek-controller: &ZEEK_CONTROLLER
   command: /usr/local/zeek/bin/zeek -j site/testing/controller.zeek
   ports:
     - "2149"
     - "2150"
+  ulimits:
+    nofile: 1024
 
 services:
   controller:

--- a/Docker/setups/singlehost/docker-compose.yml
+++ b/Docker/setups/singlehost/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3"
 # docker-compose requires the x- prefix for unrelated YAML nodes
 x-zeek-template: &ZEEK_BASE
   image: zeektest:latest
+  ulimits:
+    nofile: 1024
 
 x-zeek-controller: &ZEEK_CONTROLLER
   command: /usr/local/zeek/bin/zeek -j "site/testing/${ZEEK_ENTRYPOINT:-controller-and-agent.zeek}"


### PR DESCRIPTION
Just two quick tweaks here — the biggie being one to clamp down the limit on open files so we don't run into [libqueue allocating 8GB+ of memory](https://github.com/mheily/libkqueue/issues/153) due to containerd's lack of a limit.