### PR TITLE
Add apt-utils package to Docker images

### DIFF
--- a/Docker/docker.final/Dockerfile
+++ b/Docker/docker.final/Dockerfile
@@ -7,6 +7,7 @@ ENV PYTHONPATH="/usr/local/zeek/lib/zeek/python"
 # This installs the same set of packages we also provide in the official Docker image.
 RUN apt-get -q update \
  && apt-get install -q -y --no-install-recommends \
+     apt-utils \
      ca-certificates \
      git \
      libmaxminddb0 \

--- a/Docker/docker.prebuild/Dockerfile
+++ b/Docker/docker.prebuild/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Christian Kreibich <christian@corelight.com>"
 # Configure system for build.
 RUN apt-get -q update \
  && apt-get install -q -y --no-install-recommends \
+     apt-utils \
      bind9 \
      bison \
      ccache \


### PR DESCRIPTION
This should potentially fix the problems seen with the prometheus tests, such as [here](https://api.cirrus-ci.com/v1/task/5518215483228160/logs/test.log):

```[21:24:17.480] cd testing/external/zeek-testing-cluster && ../../../auxil/btest/btest -A -d -b -j ${ZEEK_CI_BTEST_JOBS}
[21:25:13.200] [#4] tests.prometheus-defaults ... failed
[21:25:13.200]   % 'bash /zeek/testing/external/zeek-testing-cluster/.tmp/tests.prometheus-defaults/prometheus-defaults.sh' failed unexpectedly (exit code 141)
[21:25:13.200]   % cat .stderr
[21:25:13.200]    Network tests_prometheus_defaults__default  Creating
[21:25:13.200]    Network tests_prometheus_defaults__default  Created
[21:25:13.200]    Container tests_prometheus_defaults__client_1  Creating
[21:25:13.200]    Container tests_prometheus_defaults__controller_1  Creating
[21:25:13.200]    Container tests_prometheus_defaults__controller_1  Created
[21:25:13.200]    Container tests_prometheus_defaults__client_1  Created
[21:25:13.200]    Container tests_prometheus_defaults__client_1  Starting
[21:25:13.200]    Container tests_prometheus_defaults__controller_1  Starting
[21:25:13.200]    Container tests_prometheus_defaults__controller_1  Started
[21:25:13.200]    Container tests_prometheus_defaults__client_1  Started
[21:25:13.200]   debconf: delaying package configuration, since apt-utils is not installed
[21:25:13.200] 
[21:25:17.290] [#1] tests.prometheus-multihost ... failed
[21:25:17.290]   % 'bash /zeek/testing/external/zeek-testing-cluster/.tmp/tests.prometheus-multihost/prometheus-multihost.sh' failed unexpectedly (exit code 141)
[21:25:17.290]   % cat .stderr
[21:25:17.290]    Network tests_prometheus_multihost__default  Creating
[21:25:17.290]    Network tests_prometheus_multihost__default  Created
[21:25:17.290]    Container tests_prometheus_multihost__client_1  Creating
[21:25:17.290]    Container tests_prometheus_multihost__controller_1  Creating
[21:25:17.290]    Container tests_prometheus_multihost__inst1_1  Creating
[21:25:17.290]    Container tests_prometheus_multihost__inst2_1  Creating
[21:25:17.290]    Container tests_prometheus_multihost__controller_1  Created
[21:25:17.290]    Container tests_prometheus_multihost__inst1_1  Created
[21:25:17.290]    Container tests_prometheus_multihost__client_1  Created
[21:25:17.290]    Container tests_prometheus_multihost__inst2_1  Created
[21:25:17.290]    Container tests_prometheus_multihost__inst1_1  Starting
[21:25:17.290]    Container tests_prometheus_multihost__inst2_1  Starting
[21:25:17.290]    Container tests_prometheus_multihost__client_1  Starting
[21:25:17.290]    Container tests_prometheus_multihost__controller_1  Starting
[21:25:17.290]    Container tests_prometheus_multihost__inst1_1  Started
[21:25:17.290]    Container tests_prometheus_multihost__controller_1  Started
[21:25:17.290]    Container tests_prometheus_multihost__inst2_1  Started
[21:25:17.290]    Container tests_prometheus_multihost__client_1  Started
[21:25:17.290]   debconf: delaying package configuration, since apt-utils is not installed
[21:25:17.290] 
[21:25:42.883] 2 of 43 tests failed
```

The zeek-side PR is https://github.com/zeek/zeek/pull/3821