### PR TITLE
Expand use of volumes (bind mounts) during testing

### DIFF
--- a/Docker/setups/multihost/docker-compose.yml
+++ b/Docker/setups/multihost/docker-compose.yml
@@ -7,6 +7,8 @@ x-zeek-template: &ZEEK_BASE
 x-zeek-controller: &ZEEK_CONTROLLER
   command: /usr/local/zeek/bin/zeek -j site/testing/controller.zeek
   environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
     - ZEEK_DEFAULT_LISTEN_ADDRESS=0.0.0.0
     - ZEEK_MANAGEMENT_SPOOL_DIR
     - ZEEK_MANAGEMENT_STATE_DIR
@@ -21,6 +23,8 @@ x-zeek-controller: &ZEEK_CONTROLLER
 x-zeek-agent: &ZEEK_AGENT
   command: /usr/local/zeek/bin/zeek -j site/testing/agent.zeek
   environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
     - ZEEK_DEFAULT_LISTEN_ADDRESS=0.0.0.0
     - ZEEK_MANAGEMENT_SPOOL_DIR
     - ZEEK_MANAGEMENT_STATE_DIR
@@ -37,6 +41,9 @@ x-zeek-client: &ZEEK_CLIENT
   volumes:
     - ./scripts:/usr/local/bin:z
     - ./etc:/usr/local/etc:z
+  environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
 
 services:
   controller:

--- a/Docker/setups/multihost/docker-compose.yml
+++ b/Docker/setups/multihost/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 # docker-compose requires the x- prefix for unrelated YAML nodes
 x-zeek-template: &ZEEK_BASE
   image: zeektest:latest

--- a/Docker/setups/multihost/docker-compose.yml
+++ b/Docker/setups/multihost/docker-compose.yml
@@ -16,9 +16,6 @@ x-zeek-controller: &ZEEK_CONTROLLER
   expose:
     - "2149"
     - "2150"
-  volumes:
-    - ./zeekscripts:/usr/local/zeek/share/zeek/site/testing:z
-    - ./scripts:/usr/local/bin:z
 
 x-zeek-agent: &ZEEK_AGENT
   command: /usr/local/zeek/bin/zeek -j site/testing/agent.zeek
@@ -32,15 +29,9 @@ x-zeek-agent: &ZEEK_AGENT
   expose:
     - "2151"
     - "9090-9999"
-  volumes:
-    - ./zeekscripts:/usr/local/zeek/share/zeek/site/testing:z
-    - ./scripts:/usr/local/bin:z
 
 x-zeek-client: &ZEEK_CLIENT
   tty: true
-  volumes:
-    - ./scripts:/usr/local/bin:z
-    - ./etc:/usr/local/etc:z
   environment:
     - DEBIAN_FRONTEND=noninteractive
     - DEBCONF_NOWARNINGS=yes
@@ -48,16 +39,33 @@ x-zeek-client: &ZEEK_CLIENT
 services:
   controller:
     hostname: controller
+    volumes:
+      - ./zeekscripts:/usr/local/zeek/share/zeek/site/testing:z
+      - ./scripts:/usr/local/bin:z
+      - ./etc:/usr/local/etc:z
+      - ./services/controller/run:/tmp/run:z
     <<: [*ZEEK_BASE, *ZEEK_CONTROLLER]
 
   inst1:
     hostname: inst1
+    volumes:
+      - ./zeekscripts:/usr/local/zeek/share/zeek/site/testing:z
+      - ./scripts:/usr/local/bin:z
+      - ./services/inst1/run:/tmp/run:z
     <<: [*ZEEK_BASE, *ZEEK_AGENT]
 
   inst2:
     hostname: inst2
+    volumes:
+      - ./zeekscripts:/usr/local/zeek/share/zeek/site/testing:z
+      - ./scripts:/usr/local/bin:z
+      - ./services/inst2/run:/tmp/run:z
     <<: [*ZEEK_BASE, *ZEEK_AGENT]
 
   client:
     hostname: client
+    volumes:
+      - ./scripts:/usr/local/bin:z
+      - ./etc:/usr/local/etc:z
+      - ./services/client/run:/tmp/run:z
     <<: [*ZEEK_BASE, *ZEEK_CLIENT]

--- a/Docker/setups/singlehost/docker-compose.yml
+++ b/Docker/setups/singlehost/docker-compose.yml
@@ -17,25 +17,27 @@ x-zeek-controller: &ZEEK_CONTROLLER
     - "2149"
     - "2150"
     - "9090-9999"
-  hostname: controller
-  volumes:
-    - ./zeekscripts:/usr/local/zeek/share/zeek/site/testing:z
-    - ./scripts:/usr/local/bin:z
-    - ./etc:/usr/local/etc:z
 
 x-zeek-client: &ZEEK_CLIENT
-  hostname: client
   tty: true
   environment:
     - DEBIAN_FRONTEND=noninteractive
     - DEBCONF_NOWARNINGS=yes
-  volumes:
-    - ./scripts:/usr/local/bin:z
-    - ./etc:/usr/local/etc:z
 
 services:
   controller:
+    hostname: controller
+    volumes:
+      - ./zeekscripts:/usr/local/zeek/share/zeek/site/testing:z
+      - ./scripts:/usr/local/bin:z
+      - ./etc:/usr/local/etc:z
+      - ./services/controller/run:/tmp/run:z
     <<: [*ZEEK_BASE, *ZEEK_CONTROLLER]
 
   client:
+    hostname: client
+    volumes:
+      - ./scripts:/usr/local/bin:z
+      - ./etc:/usr/local/etc:z
+      - ./services/client/run:/tmp/run:z
     <<: [*ZEEK_BASE, *ZEEK_CLIENT]

--- a/Docker/setups/singlehost/docker-compose.yml
+++ b/Docker/setups/singlehost/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 # docker-compose requires the x- prefix for unrelated YAML nodes
 x-zeek-template: &ZEEK_BASE
   image: zeektest:latest

--- a/Docker/setups/singlehost/docker-compose.yml
+++ b/Docker/setups/singlehost/docker-compose.yml
@@ -7,6 +7,8 @@ x-zeek-template: &ZEEK_BASE
 x-zeek-controller: &ZEEK_CONTROLLER
   command: /usr/local/zeek/bin/zeek -j "site/testing/${ZEEK_ENTRYPOINT:-controller-and-agent.zeek}"
   environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
     - ZEEK_DEFAULT_LISTEN_ADDRESS=0.0.0.0
     - ZEEK_MANAGEMENT_SPOOL_DIR
     - ZEEK_MANAGEMENT_STATE_DIR
@@ -24,6 +26,9 @@ x-zeek-controller: &ZEEK_CONTROLLER
 x-zeek-client: &ZEEK_CLIENT
   hostname: client
   tty: true
+  environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
   volumes:
     - ./scripts:/usr/local/bin:z
     - ./etc:/usr/local/etc:z

--- a/Scripts/docker-compose-teardown
+++ b/Scripts/docker-compose-teardown
@@ -2,21 +2,33 @@
 
 testname=$(echo "$1" | sed 's/[^a-zA-Z0-9]/_/g')
 
+preserve_container_state_client() {
+    # Nothing so far
+    :
+}
+
 preserve_container_state() {
     local name="$1"
     local container="${testname}__${name}_1"
+    local prefix="services/$name/artifacts"
+
     if docker ps -a | grep -q "$container"; then
-        mkdir -p "$name/var"
-        docker cp "$container:/usr/local/zeek/var/lib" "$name/var/lib"
-        docker cp "$container:/usr/local/zeek/spool" "$name/spool"
-        docker cp "$container:/usr/local/zeek/logs" "$name/logs"
+        mkdir -p "$prefix/var"
+        docker cp "$container:/usr/local/zeek/var/lib" "$prefix/var/lib"
+        docker cp "$container:/usr/local/zeek/spool" "$prefix/spool"
+        docker cp "$container:/usr/local/zeek/logs" "$prefix/logs"
     fi
 }
 
-# Preserve the containers' persistent state:
-preserve_container_state controller
-preserve_container_state inst1
-preserve_container_state inst2
+# Preserve the containers' persistent state. If there's a service-specific
+# routine, use that, otherwise handle generically.
+for service in $(docker compose config --services); do
+    if [[ $(type -t "preserve_container_state_$service") == function ]]; then
+        preserve_container_state_$service
+    else
+        preserve_container_state $service
+    fi
+done
 
 # Grab the Docker logs
 docker compose -p ${testname}_ -f docker-compose.yml logs >docker-compose.logs

--- a/Scripts/docker-setup
+++ b/Scripts/docker-setup
@@ -44,6 +44,11 @@ docker_populate() {
     if [ -d $DOCKER/setups/$template/etc ]; then
         cp -pr $DOCKER/setups/$template/etc .
     fi
+
+    # Per-service directories for bind mounts available during testing.
+    for service in $(docker compose config --services); do
+        mkdir -p "./services/$service/run"
+    done
 }
 
 # The corresponding "docker compose down" happens in docker-compose-teardown.

--- a/btest.cfg
+++ b/btest.cfg
@@ -24,13 +24,12 @@ UBSAN_OPTIONS=print_stacktrace=1
 # https://stackoverflow.com/a/69519102
 # https://docs.docker.com/compose/cli-command-compatibility/
 COMPOSE_COMPATIBILITY=true
+TEST_TRACE_COMMANDS=1
 
 [environment-debug]
 # After test completion, keep all containers running regardless of test outcome.
 TEST_SKIP_DOCKER_TEARDOWN=1
-TEST_TRACE_COMMANDS=1
 
 [environment-debug-failures]
 # After test completion, keep containers of failing tests running.
 TEST_SKIP_DOCKER_TEARDOWN_ON_FAILURE=1
-TEST_TRACE_COMMANDS=1

--- a/tests/prometheus-custom.sh
+++ b/tests/prometheus-custom.sh
@@ -69,10 +69,14 @@ wait_for_all_nodes_running || fail "nodes did not end up running"
 client_cmd "curl -s http://controller:3000/services.json" \
     | jq '.[].targets |= sort' >output.manager-sd.json
 
-# Only manager and worker expose telemetry. Smoke-test presence of the version info:
-client_cmd "curl -s http://controller:3000/metrics" | tee output.manager.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:3003/metrics" | tee output.worker.dat | grep -q zeek_version_info
+# Only manager and worker expose telemetry:
+client_cmd "curl -s http://controller:3000/metrics >/tmp/run/output.manager.dat"
+client_cmd "curl -s http://controller:3003/metrics >/tmp/run/output.worker.dat"
+
+# Smoke-test presence of the version info:
+grep -q zeek_version_info ./services/client/run/output.manager.dat
+grep -q zeek_version_info ./services/client/run/output.worker.dat
 
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="worker"' output.worker.dat
+grep -q 'endpoint="manager"' ./services/client/run/output.manager.dat
+grep -q 'endpoint="worker"' ./services/client/run/output.worker.dat

--- a/tests/prometheus-defaults.sh
+++ b/tests/prometheus-defaults.sh
@@ -68,12 +68,18 @@ zeek_client "get-id-value Management::Controller::auto_assign_metrics_start_port
 client_cmd "curl -s http://controller:9000/services.json" \
     | jq '.[].targets |= sort' >output.manager-sd.json
 
-# The manager, logger, and worker also expose telemetry:
-client_cmd "curl -s http://controller:9000/metrics" | tee output.manager.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:9001/metrics" | tee output.logger.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:9002/metrics" | tee output.worker.dat | grep -q zeek_version_info
+# All nodes expose telemetry, grab it:
+client_cmd "curl -s http://controller:9000/metrics >/tmp/run/output.manager.dat"
+client_cmd "curl -s http://controller:9001/metrics >/tmp/run/output.logger.dat"
+client_cmd "curl -s http://controller:9002/metrics >/tmp/run/output.worker.dat"
+
+# Smoke-test presence of the version info:
+grep -q zeek_version_info ./services/client/run/output.manager.dat
+grep -q zeek_version_info ./services/client/run/output.logger.dat
+grep -q zeek_version_info ./services/client/run/output.worker.dat
 
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="logger"' output.logger.dat
-grep -q 'endpoint="worker"' output.worker.dat
+# Verify the node identities are as we expect:
+grep -q 'endpoint="manager"' ./services/client/run/output.manager.dat
+grep -q 'endpoint="logger"' ./services/client/run/output.logger.dat
+grep -q 'endpoint="worker"' ./services/client/run/output.worker.dat

--- a/tests/prometheus-multihost.sh
+++ b/tests/prometheus-multihost.sh
@@ -70,12 +70,17 @@ for hostport in $(jq -r '.[0].targets | join(" ")' output.manager-sd.json); do
     fi
 done
 
-# All nodes expose telemetry. Smoke-test presence of the version info:
-client_cmd "curl -s http://inst1:9000/metrics" | tee output.manager.dat | grep -q zeek_version_info
-client_cmd "curl -s http://inst1:9001/metrics" | tee output.logger.dat | grep -q zeek_version_info
-client_cmd "curl -s http://inst2:9002/metrics" | tee output.worker.dat | grep -q zeek_version_info
+# All nodes expose telemetry, grab it:
+client_cmd "curl -s http://inst1:9000/metrics >/tmp/run/output.manager.dat"
+client_cmd "curl -s http://inst1:9001/metrics >/tmp/run/output.logger.dat"
+client_cmd "curl -s http://inst2:9002/metrics >/tmp/run/output.worker.dat"
+
+# Smoke-test presence of the version info:
+grep -q zeek_version_info ./services/client/run/output.manager.dat
+grep -q zeek_version_info ./services/client/run/output.logger.dat
+grep -q zeek_version_info ./services/client/run/output.worker.dat
 
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="logger"' output.logger.dat
-grep -q 'endpoint="worker"' output.worker.dat
+grep -q 'endpoint="manager"' ./services/client/run/output.manager.dat
+grep -q 'endpoint="logger"' ./services/client/run/output.logger.dat
+grep -q 'endpoint="worker"' ./services/client/run/output.worker.dat

--- a/tests/prometheus-startport.sh
+++ b/tests/prometheus-startport.sh
@@ -72,12 +72,17 @@ wait_for_all_nodes_running || fail "nodes did not end up running"
 client_cmd "curl -s http://controller:3000/services.json" \
     | jq '.[].targets |= sort' >output.manager-sd.json
 
-# All nodes expose telemetry. Smoke-test presence of the version info:
-client_cmd "curl -s http://controller:3000/metrics" | tee output.manager.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:3001/metrics" | tee output.logger.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:3002/metrics" | tee output.worker.dat | grep -q zeek_version_info
+# All nodes expose telemetry, grab it:
+client_cmd "curl -s http://controller:3000/metrics >/tmp/run/output.manager.dat"
+client_cmd "curl -s http://controller:3001/metrics >/tmp/run/output.logger.dat"
+client_cmd "curl -s http://controller:3002/metrics >/tmp/run/output.worker.dat"
+
+# Smoke-test presence of the version info:
+grep -q zeek_version_info ./services/client/run/output.manager.dat
+grep -q zeek_version_info ./services/client/run/output.logger.dat
+grep -q zeek_version_info ./services/client/run/output.worker.dat
 
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="logger"' output.logger.dat
-grep -q 'endpoint="worker"' output.worker.dat
+grep -q 'endpoint="manager"' ./services/client/run/output.manager.dat
+grep -q 'endpoint="logger"' ./services/client/run/output.logger.dat
+grep -q 'endpoint="worker"' ./services/client/run/output.worker.dat


### PR DESCRIPTION
This is an attempt to resolve [transient errors](https://cirrus-ci.com/task/5284859575271424) with the Prometheus tests in CI. This adds a volume (a bind mount) during the test that things on either side can write to, and switches the tests to curl their output into files instead of a pipe that spans the container boundary. For example,
```
client_cmd "curl -s http://inst1:9000/metrics" | tee output.manager.dat | grep -q zeek_version_info
```
is now
```
client_cmd "curl -s http://inst1:9000/metrics >/tmp/run/output.manager.dat"
```
and further processing happens on the resulting output file.

I'm wondering whether just using `--no-buffer`  on curl would fix it, but the volume approach seems generally more useful.

This also includes some minor tweaks to reduce warnings in a couple of places, and get better logging/tracing.