### PR TITLE
Avoid tee in Prometheus scraping tests

### DIFF
--- a/tests/prometheus-custom.sh
+++ b/tests/prometheus-custom.sh
@@ -69,9 +69,13 @@ wait_for_all_nodes_running || fail "nodes did not end up running"
 client_cmd "curl -s http://controller:3000/services.json" \
     | jq '.[].targets |= sort' >output.manager-sd.json
 
-# Only manager and worker expose telemetry. Smoke-test presence of the version info:
-client_cmd "curl -s http://controller:3000/metrics" | tee output.manager.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:3003/metrics" | tee output.worker.dat | grep -q zeek_version_info
+# Only manager and worker expose telemetry:
+client_cmd "curl -s http://controller:3000/metrics" >output.manager.dat
+client_cmd "curl -s http://controller:3003/metrics" >output.worker.dat
+
+# Smoke-test presence of the version info:
+grep -q zeek_version_info output.manager.dat
+grep -q zeek_version_info output.worker.dat
 
 # Verify the node identities are as we expect:
 grep -q 'endpoint="manager"' output.manager.dat

--- a/tests/prometheus-defaults.sh
+++ b/tests/prometheus-defaults.sh
@@ -68,11 +68,17 @@ zeek_client "get-id-value Management::Controller::auto_assign_metrics_start_port
 client_cmd "curl -s http://controller:9000/services.json" \
     | jq '.[].targets |= sort' >output.manager-sd.json
 
-# The manager, logger, and worker also expose telemetry:
-client_cmd "curl -s http://controller:9000/metrics" | tee output.manager.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:9001/metrics" | tee output.logger.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:9002/metrics" | tee output.worker.dat | grep -q zeek_version_info
+# All nodes expose telemetry, grab it:
+client_cmd "curl -s http://controller:9000/metrics" >output.manager.dat
+client_cmd "curl -s http://controller:9001/metrics" >output.logger.dat
+client_cmd "curl -s http://controller:9002/metrics" >output.worker.dat
 
+# Smoke-test presence of the version info:
+grep -q zeek_version_info output.manager.dat
+grep -q zeek_version_info output.logger.dat
+grep -q zeek_version_info output.worker.dat
+
+# Verify the node identities are as we expect:
 # Verify the node identities are as we expect:
 grep -q 'endpoint="manager"' output.manager.dat
 grep -q 'endpoint="logger"' output.logger.dat

--- a/tests/prometheus-multihost.sh
+++ b/tests/prometheus-multihost.sh
@@ -70,10 +70,15 @@ for hostport in $(jq -r '.[0].targets | join(" ")' output.manager-sd.json); do
     fi
 done
 
-# All nodes expose telemetry. Smoke-test presence of the version info:
-client_cmd "curl -s http://inst1:9000/metrics" | tee output.manager.dat | grep -q zeek_version_info
-client_cmd "curl -s http://inst1:9001/metrics" | tee output.logger.dat | grep -q zeek_version_info
-client_cmd "curl -s http://inst2:9002/metrics" | tee output.worker.dat | grep -q zeek_version_info
+# All nodes expose telemetry, grab it:
+client_cmd "curl -s http://inst1:9000/metrics" >output.manager.dat
+client_cmd "curl -s http://inst1:9001/metrics" >output.logger.dat
+client_cmd "curl -s http://inst2:9002/metrics" >output.worker.dat
+
+# Smoke-test presence of the version info:
+grep -q zeek_version_info output.manager.dat
+grep -q zeek_version_info output.logger.dat
+grep -q zeek_version_info output.worker.dat
 
 # Verify the node identities are as we expect:
 grep -q 'endpoint="manager"' output.manager.dat

--- a/tests/prometheus-startport.sh
+++ b/tests/prometheus-startport.sh
@@ -72,10 +72,15 @@ wait_for_all_nodes_running || fail "nodes did not end up running"
 client_cmd "curl -s http://controller:3000/services.json" \
     | jq '.[].targets |= sort' >output.manager-sd.json
 
-# All nodes expose telemetry. Smoke-test presence of the version info:
-client_cmd "curl -s http://controller:3000/metrics" | tee output.manager.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:3001/metrics" | tee output.logger.dat | grep -q zeek_version_info
-client_cmd "curl -s http://controller:3002/metrics" | tee output.worker.dat | grep -q zeek_version_info
+# All nodes expose telemetry, grab it:
+client_cmd "curl -s http://controller:3000/metrics" >output.manager.dat
+client_cmd "curl -s http://controller:3001/metrics" >output.logger.dat
+client_cmd "curl -s http://controller:3002/metrics" >output.worker.dat
+
+# Smoke-test presence of the version info:
+grep -q zeek_version_info output.manager.dat
+grep -q zeek_version_info output.logger.dat
+grep -q zeek_version_info output.worker.dat
 
 # Verify the node identities are as we expect:
 grep -q 'endpoint="manager"' output.manager.dat


### PR DESCRIPTION
As per @awelzel's analysis, the early exit of grep on the first hit coupled with 'set -e' and 'pipefail' can trigger SIGPIPE. This just works around by producing the file first, then analyzing it.

I checked existing uses of `tee` in the tests and there's a bunch, but they all pipe into `jq`, and as far as I can tell there's no early-exit behavior in it that would resemble `grep -q` here.

Revised version of #32.