### PR TITLE
Avoid warnings, add shell trace at all times

### DIFF
--- a/Docker/setups/multihost/docker-compose.yml
+++ b/Docker/setups/multihost/docker-compose.yml
@@ -7,6 +7,8 @@ x-zeek-template: &ZEEK_BASE
 x-zeek-controller: &ZEEK_CONTROLLER
   command: /usr/local/zeek/bin/zeek -j site/testing/controller.zeek
   environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
     - ZEEK_DEFAULT_LISTEN_ADDRESS=0.0.0.0
     - ZEEK_MANAGEMENT_SPOOL_DIR
     - ZEEK_MANAGEMENT_STATE_DIR
@@ -21,6 +23,8 @@ x-zeek-controller: &ZEEK_CONTROLLER
 x-zeek-agent: &ZEEK_AGENT
   command: /usr/local/zeek/bin/zeek -j site/testing/agent.zeek
   environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
     - ZEEK_DEFAULT_LISTEN_ADDRESS=0.0.0.0
     - ZEEK_MANAGEMENT_SPOOL_DIR
     - ZEEK_MANAGEMENT_STATE_DIR
@@ -37,6 +41,9 @@ x-zeek-client: &ZEEK_CLIENT
   volumes:
     - ./scripts:/usr/local/bin:z
     - ./etc:/usr/local/etc:z
+  environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
 
 services:
   controller:

--- a/Docker/setups/multihost/docker-compose.yml
+++ b/Docker/setups/multihost/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 # docker-compose requires the x- prefix for unrelated YAML nodes
 x-zeek-template: &ZEEK_BASE
   image: zeektest:latest

--- a/Docker/setups/singlehost/docker-compose.yml
+++ b/Docker/setups/singlehost/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 # docker-compose requires the x- prefix for unrelated YAML nodes
 x-zeek-template: &ZEEK_BASE
   image: zeektest:latest

--- a/Docker/setups/singlehost/docker-compose.yml
+++ b/Docker/setups/singlehost/docker-compose.yml
@@ -7,6 +7,8 @@ x-zeek-template: &ZEEK_BASE
 x-zeek-controller: &ZEEK_CONTROLLER
   command: /usr/local/zeek/bin/zeek -j "site/testing/${ZEEK_ENTRYPOINT:-controller-and-agent.zeek}"
   environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
     - ZEEK_DEFAULT_LISTEN_ADDRESS=0.0.0.0
     - ZEEK_MANAGEMENT_SPOOL_DIR
     - ZEEK_MANAGEMENT_STATE_DIR
@@ -24,6 +26,9 @@ x-zeek-controller: &ZEEK_CONTROLLER
 x-zeek-client: &ZEEK_CLIENT
   hostname: client
   tty: true
+  environment:
+    - DEBIAN_FRONTEND=noninteractive
+    - DEBCONF_NOWARNINGS=yes
   volumes:
     - ./scripts:/usr/local/bin:z
     - ./etc:/usr/local/etc:z

--- a/btest.cfg
+++ b/btest.cfg
@@ -24,13 +24,12 @@ UBSAN_OPTIONS=print_stacktrace=1
 # https://stackoverflow.com/a/69519102
 # https://docs.docker.com/compose/cli-command-compatibility/
 COMPOSE_COMPATIBILITY=true
+TEST_TRACE_COMMANDS=1
 
 [environment-debug]
 # After test completion, keep all containers running regardless of test outcome.
 TEST_SKIP_DOCKER_TEARDOWN=1
-TEST_TRACE_COMMANDS=1
 
 [environment-debug-failures]
 # After test completion, keep containers of failing tests running.
 TEST_SKIP_DOCKER_TEARDOWN_ON_FAILURE=1
-TEST_TRACE_COMMANDS=1


### PR DESCRIPTION
Remaining tweaks from former #32. Hopefully nothing contentious here — I consider the Debian envs temporary until we've resolved a way to add packages to the containers outside of the tests. More on that shortly.