### PR TITLE
Test cases for Broker's backpressure overflows

### DIFF
--- a/Scripts/test-helpers
+++ b/Scripts/test-helpers
@@ -37,15 +37,36 @@ run() {
     return 0
 }
 
-# Try a given command repeatedly for up to 5 seconds until it succeeds.
-# Returns with success if so, and failure if the command always failed.
+# Try a given command repeatedly for up to the configurable number of seconds
+# until it succeeds. The default is to try twice a second for 5 seconds. Use
+# -d/-i to pass custom delays and intervals -- these must come as first
+# arguments. Returns with success if the command eventually succeeded, and
+# failure if time ran out.
 try_until() {
-    local reps=10
-    local delay=0.5
+    local delay_secs=5
+    local delay_ival=0.5
+
+    while [ "$1" != "" ]; do
+        case "$1" in
+            "-d"|"--delay-secs")
+                delay_secs="$2"
+                shift 2
+                ;;
+            "-i"|"--interval-secs")
+                delay_ival="$2"
+                shift 2
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    local reps="$(python3 -c "print($delay_secs / $delay_ival)")"
 
     for i in $(seq $reps); do
         "$@" && return 0
-        sleep $delay
+        sleep "$delay_ival"
     done
 
     return 1

--- a/tests/backend/broker/backpressure-overflow-slow-proxy.sh
+++ b/tests/backend/broker/backpressure-overflow-slow-proxy.sh
@@ -1,0 +1,87 @@
+# @TEST-REQUIRES: $SCRIPTS/docker-requirements
+#
+# Contents of the "zeekscripts" directory become available to Zeek's containers
+# in the "testing" directory, which is part of ZEEKPATH. Most of this happens
+# via docker_populate below, but it's handy to use %DIR here.
+# @TEST-EXEC: mkdir zeekscripts && cp %DIR/backpressure-overflow/*.zeek zeekscripts
+#
+# @TEST-EXEC: bash %INPUT
+
+. $SCRIPTS/docker-setup
+. $SCRIPTS/test-helpers
+
+docker_populate singlehost
+
+# Set agent name back to its default so the framework falls back to using
+# "agent-<hostname>". This allows a minimal deployment config below.
+cat >>zeekscripts/agent-local.zeek <<EOF
+redef Management::Agent::name = "";
+EOF
+
+cat >>zeekscripts/local.zeek <<EOF
+@load frameworks/telemetry/log
+redef Telemetry::log_interval = 1sec;
+EOF
+
+docker_compose_up
+
+# For minimal deployment (without spelling out instances etc) to work, we need
+# to run on the controller machine:
+controller_cmd zeek-client -c /usr/local/etc/zeek-client.cfg deploy-config - <<EOF
+[manager]
+role = manager
+scripts = testing/manager.zeek
+env = SENDER=worker
+
+[proxy]
+role = proxy
+scripts = testing/receiver.zeek
+env = SENDER=worker ZEEK_DEFAULT_CONNECT_RETRY=5
+
+[worker]
+role = worker
+scripts = testing/sender.zeek
+interface = lo
+env = SENDER=worker ZEEK_DEFAULT_CONNECT_RETRY=5
+EOF
+
+wait_for_all_nodes_running || fail "nodes did not end up running"
+
+proxy_logs=/usr/local/zeek/var/lib/nodes/proxy
+worker_logs=/usr/local/zeek/var/lib/nodes/worker
+manager_logs=/usr/local/zeek/var/lib/nodes/manager
+
+# Nodes are up. Verify that the proxy locks up in the script layer:
+try_until -d 20 -i 1 controller_cmd "grep WEDGING $proxy_logs/stdout" \
+    || fail "proxy never ended up wedging"
+
+# Now wait until the worker sees backpressure-induced unpeering. This can take a while.
+try_until -d 60 -i 1 controller_cmd "grep 'removed due to backpressure' $worker_logs/cluster.log" \
+    || fail "worker never saw backpressure"
+
+# Un-wedge the proxy:
+controller_cmd "touch /tmp/zeek-unwedge"
+
+# Verify this worked -- that should be quick:
+try_until controller_cmd "grep UNWEDGED $proxy_logs/stdout" \
+    || fail "proxy never got unwedged"
+
+# Now verify connectivity recovered, in the proxy...
+try_until -d 30 controller_cmd "grep RECOVERED $proxy_logs/stdout" \
+    || fail "proxy never recovered"
+
+# ... and in the worker's cluster.log. We look for a hello from the proxy after
+# the backpressure overflow notification.
+try_until -d 10 controller_cmd "cat $worker_logs/cluster.log " \
+    "| awk 'f{print} /removed due to backpressure/{f=1}' " \
+    "| grep 'got hello from proxy'"
+
+# The worker's telemetry also should report the unpeering by now.
+# "worker,proxy" captures that the worker observed the proxy falling behind.
+try_until controller_cmd "cat $worker_logs/telemetry.log " \
+    "| grep -E 'zeek_broker_backpressure_disconnects_total.+worker,proxy.+1.0'" \
+    || fail "telemetry did not report backpressure disconnect"
+
+# Verify that the manager never detected a lockup.
+controller_cmd "grep -q -v LOCKUP $manager_logs/stdout" \
+    || fail "manager diagnosed a sender lockup"

--- a/tests/backend/broker/backpressure-overflow-slow-worker.sh
+++ b/tests/backend/broker/backpressure-overflow-slow-worker.sh
@@ -1,0 +1,87 @@
+# @TEST-REQUIRES: $SCRIPTS/docker-requirements
+#
+# Contents of the "zeekscripts" directory become available to Zeek's containers
+# in the "testing" directory, which is part of ZEEKPATH. Most of this happens
+# via docker_populate below, but it's handy to use %DIR here.
+# @TEST-EXEC: mkdir zeekscripts && cp %DIR/backpressure-overflow/*.zeek zeekscripts
+#
+# @TEST-EXEC: bash %INPUT
+
+. $SCRIPTS/docker-setup
+. $SCRIPTS/test-helpers
+
+docker_populate singlehost
+
+# Set agent name back to its default so the framework falls back to using
+# "agent-<hostname>". This allows a minimal deployment config below.
+cat >>zeekscripts/agent-local.zeek <<EOF
+redef Management::Agent::name = "";
+EOF
+
+cat >>zeekscripts/local.zeek <<EOF
+@load frameworks/telemetry/log
+redef Telemetry::log_interval = 1sec;
+EOF
+
+docker_compose_up
+
+# For minimal deployment (without spelling out instances etc) to work, we need
+# to run on the controller machine:
+controller_cmd zeek-client -c /usr/local/etc/zeek-client.cfg deploy-config - <<EOF
+[manager]
+role = manager
+scripts = testing/manager.zeek
+env = SENDER=proxy
+
+[proxy]
+role = proxy
+scripts = testing/sender.zeek
+env = SENDER=proxy ZEEK_DEFAULT_CONNECT_RETRY=5
+
+[worker]
+role = worker
+scripts = testing/receiver.zeek
+interface = lo
+env = SENDER=proxy ZEEK_DEFAULT_CONNECT_RETRY=5
+EOF
+
+wait_for_all_nodes_running || fail "nodes did not end up running"
+
+proxy_logs=/usr/local/zeek/var/lib/nodes/proxy
+worker_logs=/usr/local/zeek/var/lib/nodes/worker
+manager_logs=/usr/local/zeek/var/lib/nodes/manager
+
+# Nodes are up. Verify that the worker locks up in the script layer:
+try_until -d 20 -i 1 controller_cmd "grep WEDGING $worker_logs/stdout" \
+    || fail "worker never ended up wedging"
+
+# Now wait until the proxy sees backpressure-induced unpeering. This can take a while.
+try_until -d 60 -i 1 controller_cmd "grep 'removed due to backpressure' $proxy_logs/cluster.log" \
+    || fail "proxy never saw backpressure"
+
+# Un-wedge the worker:
+controller_cmd "touch /tmp/zeek-unwedge"
+
+# Verify this worked -- that should be quick:
+try_until controller_cmd "grep UNWEDGED $worker_logs/stdout" \
+    || fail "worker never got unwedged"
+
+# Now verify connectivity recovered, in the worker...
+try_until -d 30 controller_cmd "grep RECOVERED $worker_logs/stdout" \
+    || fail "worker never recovered"
+
+# ... and in the proxy's cluster.log. We look for a hello from the worker after
+# the backpressure overflow notification.
+try_until -d 10 controller_cmd "cat $proxy_logs/cluster.log " \
+    "| awk 'f{print} /removed due to backpressure/{f=1}' " \
+    "| grep 'got hello from worker'"
+
+# The proxy's telemetry also should report the unpeering by now.
+# "proxy,worker" captures that the proxy observed the worker falling behind.
+try_until controller_cmd "cat $proxy_logs/telemetry.log " \
+    "| grep -E 'zeek_broker_backpressure_disconnects_total.+proxy,worker.+1.0'" \
+    || fail "telemetry did not report backpressure disconnect"
+
+# Verify that the manager never detected a lockup.
+controller_cmd "grep -q -v LOCKUP $manager_logs/stdout" \
+    || fail "manager diagnosed a sender lockup"

--- a/tests/backend/broker/backpressure-overflow/manager.zeek
+++ b/tests/backend/broker/backpressure-overflow/manager.zeek
@@ -1,0 +1,45 @@
+# The manager sends its own type of low-frequency pings to the sender and tracks
+# their roundtrip back to it. When response pings go missing for too long, the
+# manager concludes the sender is locked up (which should never happen).
+
+# Where to send the ping. The manager always sends to the node generating the
+# load (the sender), not the one locking up (the receiver).
+global ping_topic = getenv("SENDER") == "proxy" ? Cluster::proxy_topic : Cluster::worker_topic;
+
+global ping_ival: interval = 0.5sec;
+global max_ping_delay: interval = 20sec;
+global last_ping_rx: time = 0;
+global lockup_notified = F;
+global counter = 0; # A ping counter.
+
+# This came back to us from the target, completing a ping roundtrip.
+event manager_ping(ctr: count)
+	{
+	last_ping_rx = current_time();
+	}
+
+event driver() {
+	Broker::publish(ping_topic, manager_ping, ++counter);
+
+	local now = current_time();
+
+	if ( time_to_double(last_ping_rx) > 0.0 )
+		{
+		print fmt("%s %s", now, now - last_ping_rx);
+
+		# Trigger purely based on delay, not on counter value, since the
+		# startup phase isn't coordinated and initial pings may simply
+		# have gotten lost.
+		if ( now - last_ping_rx > max_ping_delay && ! lockup_notified )
+			{
+			print fmt("%s LOCKUP", current_time());
+			lockup_notified = T;
+			}
+		}
+
+	schedule ping_ival { driver() };
+}
+
+event zeek_init() {
+	schedule ping_ival { driver() };
+}

--- a/tests/backend/broker/backpressure-overflow/receiver.zeek
+++ b/tests/backend/broker/backpressure-overflow/receiver.zeek
@@ -1,0 +1,46 @@
+# The receiver of ping events locks itself up in the script layer after
+# receiving a handful of pings from the sender. It does this lockup by sitting
+# in a tight loop on sleeps, checking for the presence of a file after each
+# sleep to break the loop, and hopefully resume receiving pings from the
+# sender. Messaging to stdout provides status updates.
+
+global unwedge_file = "/tmp/zeek-unwedge"; # Presence of this file un-wedges the node.
+global epoch_rx = 0;
+global pings_rx = 0;
+global wedgie: event();
+global ping: event(epoch: count, ctr: count, padding: string);
+
+event wedgie() {
+	# Loop forever, but check occasionally whether the unwedge_file exists,
+	# and bail if so. Meanwhile pings coming in from the sender pile up.
+	print fmt("%s WEDGING", current_time());
+
+	while ( T )
+		{
+		sleep(1sec);
+
+		if (file_size(unwedge_file) >= 0.0) {
+			print fmt("%s UNWEDGED", current_time());
+			return;
+		}
+	}
+}
+
+event ping(epoch: count, ctr: count, padding: string) &is_used {
+	if ( epoch == 0 )
+		{
+		# Lock up the script layer after we've received a few pings.
+		# The pings continue to arrive but no longer make it to this
+		# event handler, since we're busy-spinning above.
+		if ( ++pings_rx == 10 )
+			event wedgie();
+		}
+
+	if ( epoch == 1 && epoch_rx == 0 )
+		{
+		# We're starting to see pings again post-wedgie. W00t.
+		print fmt("%s RECOVERED at ping %d", current_time(), ctr);
+		}
+
+	epoch_rx = epoch;
+}

--- a/tests/backend/broker/backpressure-overflow/sender.zeek
+++ b/tests/backend/broker/backpressure-overflow/sender.zeek
@@ -1,0 +1,61 @@
+# The sender fires batches of one-way ping events to a receiver to make it
+# consume buffer space. An included epoch counter tracks how often we'receiving
+# backpressure-induced unpeerings. While this is happening, the sender also
+# receives ping events (of a different type) from the manager, which it echoes
+# back to it. This verifies that the sender itself does not lock up. Messaging
+# to stdout provides status updates.
+
+# Where to send the ping, controlled by the SENDER environment variable. We will
+# either generate load worker->proxy, or proxy->worker.
+global ping_topic = getenv("SENDER") == "proxy" ? Cluster::worker_topic : Cluster::proxy_topic;
+
+global padding: string = string_fill(256, "1234567890"); # To eat buffer space
+global ping_ival: interval = 0.01sec; # Rapdid, to eat up space quickly
+
+# Number of pings to send in one batch. This triggers overflow much more
+# quickly, since buffer limits operate on message granularity.
+global ping_batch = 20;
+
+global epoch = 0; # Epochs increase with every backpressure-triggered de-peering
+global counter = 0; # A ping counter.
+
+# A ping from manager to worker that the worker echoes back, to verify
+# liveness of that peering. This should always keep chugging -- if not, it means
+# the worker's I/O troubles propagate to the manager: global lockup.
+global manager_ping: event(ctr: count);
+
+# A one-way ping to our target. It consumes space via a padding string to speed
+# up backpressure. The epoch increases every time a backpressure unpeering
+# occurs in the target.
+global ping: event(epoch: count, ctr: count, padding: string);
+
+event Broker::peer_removed(endpoint: Broker::EndpointInfo, msg: string)
+	{
+	if ( "caf::sec::backpressure_overflow" !in msg )
+		return;
+
+	# This is our signal that the proxy is gone. We keep sending pings
+	# and bump up the epoch to distinguish before/after the de-peering.
+
+	++epoch;
+	print fmt("%s UNPEERED, epoch now %d", current_time(), epoch);
+	}
+
+# This comes from the manager. We echo it back.
+event manager_ping(ctr: count) &is_used
+	{
+	Broker::publish(Cluster::manager_topic, manager_ping, ctr);
+	}
+
+event driver()
+	{
+	local i = 0;
+	while ( ++i < ping_batch )
+		Broker::publish(ping_topic, ping, epoch, ++counter, padding);
+
+	schedule ping_ival { driver() };
+	}
+
+event zeek_init() {
+	schedule ping_ival { driver() };
+}


### PR DESCRIPTION
I figured the cluster testsuite is a better place for these since they're somewhat involved and a little more "out of the way" than Zeek's own btests. The idea for the two tests is the same: a sender keeps firing events at a receiver, and we lock up the receiver in the script layer until message backpressure propagates to the sender and Broker's force-disconnect kicks in. The test then verifies that the cluster recovers when we subsequently un-wedge the receiver.

In one test the (single) worker acts as the sender and the (single) proxy as the receiver, and vice versa in the other test. They're otherwise identical.

In both cases, the sender also echoes back unrelated pings it gets from the manager, and the manager verifies that this event flow remains active. If it doesn't, the slow receiver's behavior is stalling the sender, which would mean we have the cascading cluster-wide lockup that was possible in the past.

Companion to zeek/zeek#3981.