### PR TITLE
Adapt Prometheus port-autoenumeration tests to new per-instance numbering

### DIFF
--- a/tests/prometheus-singlehost-multi-instance.sh
+++ b/tests/prometheus-singlehost-multi-instance.sh
@@ -1,6 +1,7 @@
 # Verify that Prometheus metrics ports auto-assignment leads to ports across the
-# cluster as expected. This uses a multi-host scenario, with two containers each
-# running an instance.
+# cluster as expected. This uses a single-host scenario with the (somewhat
+# unusual) scenario of multiple instances running on it. The point to look out
+# for here is that port assignment doesn't clash.
 #
 # @TEST-REQUIRES: $SCRIPTS/docker-requirements
 # @TEST-EXEC: bash %INPUT
@@ -8,19 +9,38 @@
 . $SCRIPTS/docker-setup
 . $SCRIPTS/test-helpers
 
-docker_populate multihost
+docker_populate singlehost
 
 # The testsuite disables metrics port auto-assignment, re-enable:
 cat >>zeekscripts/controller-local.zeek <<EOF
 redef Management::Controller::auto_assign_metrics_ports = T;
 EOF
 
-docker_compose_up
+# Run a "bare" controller without agents:
+ZEEK_ENTRYPOINT=controller.zeek docker_compose_up
+
+# Run two agents alongside, both connecting to the controller:
+docker_exec controller mkdir /tmp/agent1 /tmp/agent2
+
+docker_exec -d -w /tmp/agent1 -- controller zeek -j site/testing/agent.zeek \
+    Management::Agent::name=agent-inst1 \
+    Broker::default_port=10000/tcp
+
+# The second agent still needs a listening port because cluster nodes created by
+# agents always peer with them.
+docker_exec -d -w /tmp/agent2 -- controller zeek -j site/testing/agent.zeek \
+    Management::Agent::default_port=2152/tcp \
+    Management::Agent::name=agent-inst2 \
+    Broker::default_port=10001/tcp
 
 # Add curl in the client container. We do this at runtime so it works with both
 # this testsuite's development container and the official Zeek one, as built in
 # our regular CI.
 client_cmd "apt-get -q update && apt-get install -q -y --no-install-recommends curl"
+
+# We need the IP address of the controller (which runs everything -- agents &
+# cluster) so we can put it in place throughout the configuration.
+controller_ip=$(client_cmd "getent hosts controller" | cut -d' ' -f1)
 
 # We're not providing names to the agents launched via docker-compose, so this
 # uses auto-generated names:
@@ -45,31 +65,14 @@ EOF
 
 wait_for_all_nodes_running || fail "nodes did not end up running"
 
-# To verify that service discovery shows the right IP addresses, we need to
-# retrieve them first.
-inst1_ip=$(client_cmd "getent hosts inst1" | cut -d' ' -f1)
-inst2_ip=$(client_cmd "getent hosts inst2" | cut -d' ' -f1)
-
-# The manager exposes a discovery endpoint. We don't baseline it because its IP
-# addresses will differ from run to run. We can do better once we support
-# hostnames as well.
-client_cmd "curl -s http://inst1:9000/services.json" \
+# The manager exposes a discovery endpoint:
+client_cmd "curl -s http://controller:9000/services.json" \
     | jq '.[].targets |= sort' >output.manager-sd.json
 
-for hostport in $(jq -r '.[0].targets | join(" ")' output.manager-sd.json); do
-    host=$(echo "$hostport" | cut -d: -f1)
-    if [[ $host != $inst1_ip ]] && [[ $host != $inst2_ip ]]; then
-        fail "unexpected host in service discovery: $host"
-    fi
-done
-
 # All nodes expose telemetry, grab it:
-client_cmd "curl -s http://inst1:9000/metrics" >output.manager.dat
-client_cmd "curl -s http://inst1:9001/metrics" >output.logger.dat
-
-# Port numbering restarts at the start point on the other instance,
-# so 9000, not 9002:
-client_cmd "curl -s http://inst2:9000/metrics" >output.worker.dat
+client_cmd "curl -s http://controller:9000/metrics" >output.manager.dat
+client_cmd "curl -s http://controller:9001/metrics" >output.logger.dat
+client_cmd "curl -s http://controller:9002/metrics" >output.worker.dat
 
 # Smoke-test presence of the version info:
 grep -q zeek_version_info output.manager.dat


### PR DESCRIPTION
For `prometheus-multihost`, this means the port numbering on the second instance should start from the start port rather than continuing the previous sequence, and for the new `prometheus-singlehost-multi-instance` test, which runs two agents alongside the controller, the enumeration should understand it's on the same host and thus enumerate continuously.

I realized while working on this that we have a handful of tests that run two instances this way, and there are better ways to do this (we can simplify launching an agent, plus we could just use multiple containers now like in `prometheus-multihost`). I'll make a pass over these but kept the same approach here for now.