### PR TITLE
Generally wait until agents and controller are connected before testing

### DIFF
--- a/tests/backend/broker/backpressure-overflow-slow-proxy.sh
+++ b/tests/backend/broker/backpressure-overflow-slow-proxy.sh
@@ -25,6 +25,9 @@ EOF
 
 docker_compose_up
 
+# Give agent time to connect to the controller.
+wait_for_instances 1
+
 # For minimal deployment (without spelling out instances etc) to work, we need
 # to run on the controller machine:
 controller_cmd zeek-client -c /usr/local/etc/zeek-client.cfg deploy-config - <<EOF

--- a/tests/backend/broker/backpressure-overflow-slow-worker.sh
+++ b/tests/backend/broker/backpressure-overflow-slow-worker.sh
@@ -25,6 +25,9 @@ EOF
 
 docker_compose_up
 
+# Give agent time to connect to the controller.
+wait_for_instances 1
+
 # For minimal deployment (without spelling out instances etc) to work, we need
 # to run on the controller machine:
 controller_cmd zeek-client -c /usr/local/etc/zeek-client.cfg deploy-config - <<EOF

--- a/tests/deploy-a2c-common.sh
+++ b/tests/deploy-a2c-common.sh
@@ -5,6 +5,9 @@
 # The Zeek host runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
 
+# Give agent time to connect to the controller.
+wait_for_instances 1
+
 zeek_client deploy-config - <<EOF
 [instances]
 instance-1

--- a/tests/deploy-agent-only.sh
+++ b/tests/deploy-agent-only.sh
@@ -13,6 +13,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 zeek_client deploy-config - <<EOF | tee output.zc | jq '.results.id = "xxx"' >output
 [instances]

--- a/tests/deploy-error.sh
+++ b/tests/deploy-error.sh
@@ -13,6 +13,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 # Let's break the logger:
 docker_exec -i -- controller 'echo EEEK >>  $(zeek-config --script_dir)/base/frameworks/cluster/nodes/logger.zeek'

--- a/tests/deploy-minimal.sh
+++ b/tests/deploy-minimal.sh
@@ -18,6 +18,10 @@ EOF
 
 docker_compose_up
 
+# Give agent time to connect to the controller. This isn't technically required
+# for deploy-config (given internal retries), but ensures race-free output below.
+wait_for_instances 1
+
 # For the minimal deployment to work, we need to run it locally on the
 # controller machine, not as in the other tests from its own container:
 controller_cmd zeek-client -c /usr/local/etc/zeek-client.cfg deploy-config - <<EOF

--- a/tests/get-config.sh
+++ b/tests/get-config.sh
@@ -20,6 +20,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 zeek_client get-config >output-preupload-staged.error 2>&1 \
     && fail "zeek-client get-config without upload did not fail"

--- a/tests/get-id-value.sh
+++ b/tests/get-id-value.sh
@@ -73,6 +73,9 @@ docker_exec -d -w /tmp/agent2 -- controller zeek -j site/testing/agent.zeek \
     Management::Agent::name=instance-2 \
     Broker::default_port=10001/tcp
 
+# Give agents time to connect to the controller:
+wait_for_instances 2
+
 # Don't exit on error since we want to examine exit codes.
 set +e
 

--- a/tests/get-nodes.sh
+++ b/tests/get-nodes.sh
@@ -11,7 +11,7 @@
 docker_populate singlehost
 docker_compose_up
 
-# Give agent time time to connect to the controller:
+# Give agent time to connect to the controller:
 wait_for_instances 1
 
 # We now run a controller named "controller" and an agent named "instance-1"

--- a/tests/log-archival-different-cmd.sh
+++ b/tests/log-archival-different-cmd.sh
@@ -53,6 +53,9 @@ EOF
 
 docker_compose_up
 
+# Give agent time to connect to the controller:
+wait_for_instances 1
+
 # This needs "ps" on the controller:
 controller_cmd "apt-get -q update && apt-get install -q -y --no-install-recommends procps"
 

--- a/tests/log-archival.sh
+++ b/tests/log-archival.sh
@@ -50,6 +50,9 @@ EOF
 
 docker_compose_up
 
+# Give agent time to connect to the controller:
+wait_for_instances 1
+
 # This needs "ps" on the controller
 controller_cmd "apt-get -q update && apt-get install -q -y --no-install-recommends procps"
 

--- a/tests/persistence-customdirs.sh
+++ b/tests/persistence-customdirs.sh
@@ -24,6 +24,9 @@ export ZEEK_MANAGEMENT_STATE_DIR=/var/lib/zeek
 
 docker_compose_up
 
+# Give agent time to connect to the controller:
+wait_for_instances 1
+
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings. Deploy a small
 # cluster:

--- a/tests/persistence-default.sh
+++ b/tests/persistence-default.sh
@@ -9,6 +9,9 @@
 docker_populate singlehost
 docker_compose_up
 
+# Give agent time to connect to the controller:
+wait_for_instances 1
+
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings. Deploy a small
 # cluster:

--- a/tests/persistence-rotation.sh
+++ b/tests/persistence-rotation.sh
@@ -18,6 +18,9 @@ EOF
 
 docker_compose_up
 
+# Give agent time to connect to the controller:
+wait_for_instances 1
+
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings. Deploy a small
 # cluster:

--- a/tests/persistence-state-restart-agent.sh
+++ b/tests/persistence-state-restart-agent.sh
@@ -26,6 +26,9 @@ docker_exec -d -w /tmp/agent2 -- controller zeek -j site/testing/agent.zeek \
     Management::Agent::name=instance-2 \
     Broker::default_port=10001/tcp
 
+# Give agents time to connect to the controller:
+wait_for_instances 2
+
 # This needs "ps":
 controller_cmd "apt-get -q update && apt-get install -q -y --no-install-recommends procps"
 

--- a/tests/persistence-state-restart-all.sh
+++ b/tests/persistence-state-restart-all.sh
@@ -31,16 +31,13 @@ EOF
 
 docker_compose_up
 
-# The Zeek host now runs a controller named "controller" and an agent named
-# "instance-1" that connects to it, with default settings.
-
 # This needs "ps" and "sqlite3" in the controller's container:
 controller_cmd "apt-get -q update && apt-get install -q -y --no-install-recommends procps sqlite3"
 
 # Now launch controller and agent in a new Zeek process tree:
 docker_exec -d -- controller /usr/local/zeek/bin/zeek -j site/testing/controller-and-agent.zeek
 
-# Give agent time time to connect to the controller:
+# Give agent time to connect to the controller:
 wait_for_instances 1
 
 # Deploy a Zeek cluster and give its nodes time to come up:

--- a/tests/persistence-state-restart-controller.sh
+++ b/tests/persistence-state-restart-controller.sh
@@ -11,6 +11,9 @@
 docker_populate singlehost
 docker_compose_up
 
+# Give agent time to connect to the controller.
+wait_for_instances 1
+
 # This needs "ps" and "sqlite3":
 controller_cmd "apt-get -q update && apt-get install -q -y --no-install-recommends procps sqlite3"
 

--- a/tests/prometheus-custom.sh
+++ b/tests/prometheus-custom.sh
@@ -24,6 +24,9 @@ EOF
 
 docker_compose_up
 
+# Give agent time to connect to the controller.
+wait_for_instances 1
+
 # Add curl in the client container. We do this at runtime so it works with both
 # this testsuite's development container and the official Zeek one, as built in
 # our regular CI.

--- a/tests/prometheus-defaults.sh
+++ b/tests/prometheus-defaults.sh
@@ -19,6 +19,9 @@ EOF
 
 docker_compose_up
 
+# Give agent time to connect to the controller.
+wait_for_instances 1
+
 # Add curl in the client container. We do this at runtime so it works with both
 # this testsuite's development container and the official Zeek one, as built in
 # our regular CI.

--- a/tests/prometheus-disabled.sh
+++ b/tests/prometheus-disabled.sh
@@ -10,8 +10,10 @@
 docker_populate singlehost
 
 # The testsuite already disables metrics port auto-assignment.
-
 docker_compose_up
+
+# Give agent time to connect to the controller.
+wait_for_instances 1
 
 # Add curl in the client container. We do this at runtime so it works with both
 # this testsuite's development container and the official Zeek one, as built in

--- a/tests/prometheus-multihost.sh
+++ b/tests/prometheus-multihost.sh
@@ -17,6 +17,9 @@ EOF
 
 docker_compose_up
 
+# Give agents time to connect to the controller.
+wait_for_instances 2
+
 # Add curl in the client container. We do this at runtime so it works with both
 # this testsuite's development container and the official Zeek one, as built in
 # our regular CI.

--- a/tests/prometheus-singlehost-multi-instance.sh
+++ b/tests/prometheus-singlehost-multi-instance.sh
@@ -33,6 +33,9 @@ docker_exec -d -w /tmp/agent2 -- controller zeek -j site/testing/agent.zeek \
     Management::Agent::name=agent-inst2 \
     Broker::default_port=10001/tcp
 
+# Give agents time to connect to the controller.
+wait_for_instances 2
+
 # Add curl in the client container. We do this at runtime so it works with both
 # this testsuite's development container and the official Zeek one, as built in
 # our regular CI.

--- a/tests/prometheus-startport.sh
+++ b/tests/prometheus-startport.sh
@@ -28,6 +28,7 @@ services:
 EOF
 
 docker_compose_up
+wait_for_instances 1
 
 # Add curl in the client container. We do this at runtime so it works with both
 # this testsuite's development container and the official Zeek one, as built in

--- a/tests/stage-config-auto-assign-new-range.sh
+++ b/tests/stage-config-auto-assign-new-range.sh
@@ -20,6 +20,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 zeek_client deploy-config - <<EOF
 [instances]

--- a/tests/stage-config-auto-assign.sh
+++ b/tests/stage-config-auto-assign.sh
@@ -15,6 +15,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 zeek_client deploy-config - <<EOF
 [instances]

--- a/tests/stage-config-conflict-node-agent-ports.sh
+++ b/tests/stage-config-conflict-node-agent-ports.sh
@@ -13,6 +13,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 # Don't exit on error since we want to examine exit codes.
 set +e

--- a/tests/stage-config-conflict-node-controller-port.sh
+++ b/tests/stage-config-conflict-node-controller-port.sh
@@ -13,6 +13,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 # Don't exit on error since we want to examine exit codes.
 set +e

--- a/tests/stage-config-conflict-node-ports.sh
+++ b/tests/stage-config-conflict-node-ports.sh
@@ -15,6 +15,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 # Don't exit on error since we want to examine exit codes.
 set +e

--- a/tests/stage-config-deploy.sh
+++ b/tests/stage-config-deploy.sh
@@ -13,6 +13,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 zeek_client deploy-config - <<EOF | jq '.results.id = "xxx"' >output
 [instances]

--- a/tests/stage-config-empty.sh
+++ b/tests/stage-config-empty.sh
@@ -13,5 +13,6 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 cat /dev/null | zeek_client deploy-config - | tee output.zc | jq '.results.id = "xxx"' >output

--- a/tests/stage-config-then-deploy.sh
+++ b/tests/stage-config-then-deploy.sh
@@ -14,6 +14,7 @@ docker_compose_up
 
 # The Zeek host now runs a controller named "controller" and an agent named
 # "instance-1" that connects to it, with default settings.
+wait_for_instances 1
 
 zeek_client stage-config - <<EOF >output
 [instances]


### PR DESCRIPTION
This fixes a large set of potential race conditions that so far were either obscured by commands that happen to be slow or were exacerbated by the recent change in the controller to augment staged configs earlier (ea88257d).

It ran a bunch of times without error via zeek/zeek#4207, see [here](https://cirrus-ci.com/task/5632597969076224).