### PR TITLE
Explicitly set "disconnect" backpressure policy in tests

### DIFF
--- a/tests/backend/broker/backpressure-overflow-slow-proxy.sh
+++ b/tests/backend/broker/backpressure-overflow-slow-proxy.sh
@@ -21,6 +21,7 @@ EOF
 cat >>zeekscripts/local.zeek <<EOF
 @load frameworks/telemetry/log
 redef Telemetry::log_interval = 1sec;
+redef Broker::peer_overflow_policy = "disconnect";
 EOF
 
 docker_compose_up

--- a/tests/backend/broker/backpressure-overflow-slow-worker.sh
+++ b/tests/backend/broker/backpressure-overflow-slow-worker.sh
@@ -21,6 +21,7 @@ EOF
 cat >>zeekscripts/local.zeek <<EOF
 @load frameworks/telemetry/log
 redef Telemetry::log_interval = 1sec;
+redef Broker::peer_overflow_policy = "disconnect";
 EOF
 
 docker_compose_up


### PR DESCRIPTION
They should always have done this, but since Zeek's default is now something else, its now a requirement. (And, we need tests for these here too...)

This complements zeek/zeek#4396.