### PR TITLE
Switch prometheus tests to check for node

### DIFF
--- a/tests/prometheus-custom.sh
+++ b/tests/prometheus-custom.sh
@@ -73,5 +73,5 @@ grep -q zeek_version_info output.manager.dat
 grep -q zeek_version_info output.worker.dat
 
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="worker"' output.worker.dat
+grep -q 'node="manager"' output.manager.dat
+grep -q 'node="worker"' output.worker.dat

--- a/tests/prometheus-defaults.sh
+++ b/tests/prometheus-defaults.sh
@@ -75,6 +75,6 @@ grep -q zeek_version_info output.worker.dat
 
 # Verify the node identities are as we expect:
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="logger"' output.logger.dat
-grep -q 'endpoint="worker"' output.worker.dat
+grep -q 'node="manager"' output.manager.dat
+grep -q 'node="logger"' output.logger.dat
+grep -q 'node="worker"' output.worker.dat

--- a/tests/prometheus-multihost.sh
+++ b/tests/prometheus-multihost.sh
@@ -80,6 +80,6 @@ grep -q zeek_version_info output.logger.dat
 grep -q zeek_version_info output.worker.dat
 
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="logger"' output.logger.dat
-grep -q 'endpoint="worker"' output.worker.dat
+grep -q 'node="manager"' output.manager.dat
+grep -q 'node="logger"' output.logger.dat
+grep -q 'node="worker"' output.worker.dat

--- a/tests/prometheus-singlehost-multi-instance.sh
+++ b/tests/prometheus-singlehost-multi-instance.sh
@@ -83,6 +83,6 @@ grep -q zeek_version_info output.logger.dat
 grep -q zeek_version_info output.worker.dat
 
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="logger"' output.logger.dat
-grep -q 'endpoint="worker"' output.worker.dat
+grep -q 'node="manager"' output.manager.dat
+grep -q 'node="logger"' output.logger.dat
+grep -q 'node="worker"' output.worker.dat

--- a/tests/prometheus-startport.sh
+++ b/tests/prometheus-startport.sh
@@ -76,6 +76,6 @@ grep -q zeek_version_info output.logger.dat
 grep -q zeek_version_info output.worker.dat
 
 # Verify the node identities are as we expect:
-grep -q 'endpoint="manager"' output.manager.dat
-grep -q 'endpoint="logger"' output.logger.dat
-grep -q 'endpoint="worker"' output.worker.dat
+grep -q 'node="manager"' output.manager.dat
+grep -q 'node="logger"' output.logger.dat
+grep -q 'node="worker"' output.worker.dat


### PR DESCRIPTION
Since zeek/zeek#4552, metrics are labeled with node, not endpoint, adapt the tests for that.